### PR TITLE
Fix token attribute retrieval

### DIFF
--- a/dump.py
+++ b/dump.py
@@ -204,8 +204,7 @@ def get_token_attributes(token: spacy.tokens.token.Token) -> Dict[str, str]:
         ):
             continue
 
-        m = f"token.{method}"
-        to_examine = eval(m)
+        to_examine = getattr(token, method)
 
         if str(type(to_examine)) == "<class 'builtin_function_or_method'>":
             continue


### PR DESCRIPTION
## Summary
- stop using `eval` to retrieve token attributes
- remove unused `m` variable

## Testing
- `python -m py_compile dump.py`

------
https://chatgpt.com/codex/tasks/task_e_68404a12243883289e6d8f757a24b0e7