### PR TITLE
Pin dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ and pickle, allowing for easy text analysis, visualization, and serialization.
 You can install the required dependencies with:
 
 ```bash
-pip install spacy lxml numpy
+pip install -r requirements.txt
 ```
 
 You'll also need to download at least one SpaCy model:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-spacy
-lxml
-numpy
+spacy>=3.0,<4.0
+lxml>=4.0,<5.0
+numpy>=1.20,<2.0


### PR DESCRIPTION
## Summary
- pin versions for `spacy`, `lxml`, and `numpy`
- document installing from `requirements.txt`

## Testing
- `python -m py_compile dump.py` *(fails: duplicate argument)*

------
https://chatgpt.com/codex/tasks/task_e_684197835ca88328adc368e9762cdc12