### PR TITLE
Add pyproject with CLI entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "nlp-dump"
+version = "0.1.0"
+description = "SpaCy dump tool for processing text files"
+authors = [{name = "Sean Evans"}]
+readme = "README.md"
+license = {file = "LICENSE"}
+requires-python = ">=3.6"
+dependencies = [
+    "spacy",
+    "lxml",
+    "numpy",
+]
+
+[project.scripts]
+nlp-dump = "dump:main"
+
+[tool.setuptools]
+py-modules = ["dump"]
+


### PR DESCRIPTION
## Summary
- enable package installation via `pyproject.toml`
- expose `nlp-dump` command pointing to `dump.main`

## Testing
- `pip install -e . --no-deps --no-build-isolation`

------
https://chatgpt.com/codex/tasks/task_e_68419784d5a08328a2e4ad4db378a67a