### PR TITLE
Fix HTML regex and compile error

### DIFF
--- a/dump.py
+++ b/dump.py
@@ -276,7 +276,7 @@ def saveas_html(
 
     html = displacy.render(doc, style="ent", options=options, page=True)
 
-    html = re.sub(r"(?:</br>\s*){2,}", "</br> ", html)
+    html = re.sub(r'(?:<br>\s*){2,}', '<br> ', html)
 
     with open(str(out_file), "w", encoding="UTF-8") as g:
         g.write(html)
@@ -410,7 +410,6 @@ def saveas(
 
 def process_file(
     file_path: Path,
-    out_dir: Path,
     nlp: spacy.language.Language,
     output_type: str,
     entity_types: List[str],
@@ -422,7 +421,6 @@ def process_file(
 
     Args:
         file_path: Path to input file
-        out_dir: Directory for output
         nlp: Loaded SpaCy model
         output_type: Output format
         entity_types: Entity types to include


### PR DESCRIPTION
## Summary
- correct regex for removing extra `<br>` tags in HTML output
- fix duplicate argument in `process_file`

## Testing
- `python -m py_compile dump.py`

------
https://chatgpt.com/codex/tasks/task_e_68419782d6048328a95a629e3dadfaf4