### PR TITLE
Remove unused import in test

### DIFF
--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -2,7 +2,6 @@ from pathlib import Path
 import sys
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-import pytest
 import spacy
 
 import dump


### PR DESCRIPTION
## Summary
- drop unused pytest import from test suite

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d64a65650832892225afecb80031d